### PR TITLE
Adds failing spec and fix for chaining of OR criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------
 
 * Compatibility with Mongoid 5.x beta - [@dblock](https://github.com/dblock).
+* Adds support for chaining $or criteria - [@sweir27](https://github.com/sweir27).
 * Your contribution here.
 
 

--- a/lib/mongoid/criterion/scrollable.rb
+++ b/lib/mongoid/criterion/scrollable.rb
@@ -19,7 +19,9 @@ module Mongoid
         cursor = cursor.is_a?(Mongoid::Scroll::Cursor) ? cursor : Mongoid::Scroll::Cursor.new(cursor, cursor_options)
         # scroll
         if block_given?
-          criteria.where(cursor.criteria).order_by(_id: scroll_direction).each do |record|
+          combo_criteria = criteria.klass.and(criteria.selector, cursor.criteria)
+          combo_criteria.options = criteria.options
+          combo_criteria.order_by(_id: scroll_direction).each do |record|
             yield record, Mongoid::Scroll::Cursor.from_record(record, cursor_options)
           end
         else


### PR DESCRIPTION
Currently, if you call `.scroll` on a mongoid criteria with an `$or` clause, the `criteria.where(...)` line does not separate the `$or` conditionals from the cursor criteria and the original criteria.

Example:
```
=> criteria
=> #<Mongoid::Criteria
  selector: {"$or"=>[{"a_time"=>{"$gt"=>2015-07-22 05:02:03 UTC}}, {"a_time"=>{"$lte"=>2015-07-22 05:02:03 UTC}, "a_date"=>{"$gte"=>2015-07-30 00:00:00 UTC}}]}
  options:  {:sort=>{"a_time"=>1}, :limit=>2}
  class:    Feed::Item
  embedded: false>
```

````
=> cursor.criteria
=> {"$or"=>[{"a_time"=>{"$gt"=>2015-02-22 06:02:03 UTC}}, {"a_time"=>2015-02-22 06:02:03 UTC, :_id=>{"$gt"=>BSON::ObjectId('55b0088c5361725886000001')}}]}
```

```
=> criteria.where(cursor.criteria)
=> #<Mongoid::Criteria
  selector: {"$or"=>[{"a_time"=>{"$gt"=>2015-07-22 05:02:03 UTC}}, {"a_time"=>{"$lte"=>2015-07-22 05:02:03 UTC}, "a_date"=>{"$gte"=>2015-07-30 00:00:00 UTC}}, {"a_time"=>{"$gt"=>2015-02-22 06:02:03 UTC}}, {"a_time"=>2015-02-22 06:02:03 UTC, "_id"=>{"$gt"=>BSON::ObjectId('55b0088c5361725886000001')}}]}
  options:  {:sort=>{"a_time"=>1}, :limit=>2}
  class:    Feed::Item
  embedded: false>
```

This is logically incorrect, as the `cursor.criteria` condition is not consistently evaluated when all of the conditions are `$or`ed together.

Note that this appears to be an underlying mongoid issue: https://github.com/mongoid/origin/issues/57

I have written a spec that breaks with the original implementation, and a fix to account for the underlying issue with chaining `$or` conditions within a `.where` query.

