### PR TITLE
(Fix) Duplicate criteria instead of constructing from scratch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 * Compatibility with Mongoid 5.x beta - [@dblock](https://github.com/dblock).
 * [#4](https://github.com/dblock/mongoid-scroll/pull/4): Fix: support chaining `$or` criteria - [@sweir27](https://github.com/sweir27).
+* [#5](https://github.com/dblock/mongoid-scroll/pull/5): Fix: embeddable objects now returned in pagination - [@sweir27](https://github.com/sweir27).
 * Your contribution here.
 
 

--- a/lib/mongoid/criterion/scrollable.rb
+++ b/lib/mongoid/criterion/scrollable.rb
@@ -19,9 +19,9 @@ module Mongoid
         cursor = cursor.is_a?(Mongoid::Scroll::Cursor) ? cursor : Mongoid::Scroll::Cursor.new(cursor, cursor_options)
         # scroll
         if block_given?
-          combo_criteria = criteria.klass.and(criteria.selector, cursor.criteria)
-          combo_criteria.options = criteria.options
-          combo_criteria.order_by(_id: scroll_direction).each do |record|
+          cursor_criteria = criteria.dup
+          cursor_criteria.selector = { '$and' => [criteria.selector, cursor.criteria] }
+          cursor_criteria.order_by(_id: scroll_direction).each do |record|
             yield record, Mongoid::Scroll::Cursor.from_record(record, cursor_options)
           end
         else

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -131,6 +131,21 @@ describe Mongoid::Criteria do
       expect(records.map(&:name)).to eq ['Feed Item 2']
     end
   end
+  context 'with embeddable objects' do
+    before do
+      @item = Feed::Item.create! a_integer: 1, name: 'item'
+      @embedded_item = Feed::EmbeddedItem.create! name: 'embedded', item: @item
+    end
+    it 'respects embedded queries' do
+      records = []
+      criteria = @item.embedded_items.limit(2)
+      criteria.scroll do |record, _next_cursor|
+        records << record
+      end
+      expect(records.size).to eq 1
+      expect(records.map(&:name)).to eq ['embedded']
+    end
+  end
   context 'with overlapping data' do
     before :each do
       3.times { Feed::Item.create! a_integer: 5 }

--- a/spec/support/feed/embedded_item.rb
+++ b/spec/support/feed/embedded_item.rb
@@ -1,0 +1,9 @@
+module Feed
+  class EmbeddedItem
+    include Mongoid::Document
+
+    field :name, type: String
+
+    embedded_in :item, inverse_of: :embedded_items
+  end
+end

--- a/spec/support/feed/item.rb
+++ b/spec/support/feed/item.rb
@@ -9,5 +9,7 @@ module Feed
     field :a_date, type: Date
     field :a_time, type: Time
     field :a_array, type: Array
+
+    embeds_many :embedded_items
   end
 end


### PR DESCRIPTION
Amazingly, this seems slightly less hacky then before.

We encountered a bug whereby embedded items were not returned in pagination. Turns out this is because when we were constructing the mongoid criteria from scratch (to correctly chain together queries), all parent associations on the criteria were not maintained, including the parent collection for an embedded object.

This PR first duplicates the original criteria, and then only changes the selector (that's all we want to modify anyways). It's cleaner because by calling `criteria.dup` we don't have to individually build each necessary attribute of the criteria.