### PR TITLE
Pre-merge cursor criteria fields

### DIFF
--- a/lib/mongoid/scroll/cursor.rb
+++ b/lib/mongoid/scroll/cursor.rb
@@ -14,7 +14,9 @@ module Mongoid
         compare_direction = direction == 1 ? '$gt' : '$lt'
         cursor_criteria = { field_name => { compare_direction => mongo_value } } if mongo_value
         tiebreak_criteria = { field_name => mongo_value, :_id => { compare_direction => tiebreak_id } } if mongo_value && tiebreak_id
-        cursor_criteria || tiebreak_criteria ? { '$or' => [cursor_criteria, tiebreak_criteria].compact } : {}
+        cursor_selector = Origin::Selector.new
+        cursor_selector.merge!('$or' => [cursor_criteria, tiebreak_criteria].compact) if cursor_criteria || tiebreak_criteria
+        cursor_selector.__evolve_object_id__
       end
 
       class << self

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -130,6 +130,19 @@ describe Mongoid::Criteria do
       expect(records.size).to eq 1
       expect(records.map(&:name)).to eq ['Feed Item 2']
     end
+    it 'merges cursor criteria when no sort field is given' do
+      criteria = Feed::Item.where(:a_time.gt => Time.new(2013, 7, 22, 1, 2, 3))
+      feed_item_1 = Feed::Item.where(name: 'Feed Item 1').first
+      cursor_input = "#{feed_item_1.id}:#{feed_item_1.id}"
+      cursor_options = { field_type: BSON::ObjectId, field_name: '_id', direction: 1 }
+      cursor = Mongoid::Scroll::Cursor.new(cursor_input, cursor_options)
+      records = []
+      criteria.limit(2).scroll(cursor) do |record, next_cursor|
+        records << record
+        cursor = next_cursor
+      end
+      expect(records.size).to eq 2
+    end
   end
   context 'with embeddable objects' do
     before do

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -134,7 +134,8 @@ describe Mongoid::Criteria do
       criteria = Feed::Item.where(:a_time.gt => Time.new(2013, 7, 22, 1, 2, 3))
       feed_item_1 = Feed::Item.where(name: 'Feed Item 1').first
       cursor_input = "#{feed_item_1.id}:#{feed_item_1.id}"
-      cursor_options = { field_type: BSON::ObjectId, field_name: '_id', direction: 1 }
+      field_type = Mongoid::Scroll.mongoid3? ? Moped::BSON::ObjectId : BSON::ObjectId
+      cursor_options = { field_type: field_type, field_name: '_id', direction: 1 }
       cursor = Mongoid::Scroll::Cursor.new(cursor_input, cursor_options)
       records = []
       criteria.limit(2).scroll(cursor) do |record, next_cursor|

--- a/spec/mongoid/scroll_cursor_spec.rb
+++ b/spec/mongoid/scroll_cursor_spec.rb
@@ -15,6 +15,19 @@ describe Mongoid::Scroll::Cursor do
                                                                                                                   /The cursor supplied is invalid: invalid./
     end
   end
+  context 'an id field cursor' do
+    let(:feed_item) { Feed::Item.create!(a_string: 'astring') }
+    subject do
+      Mongoid::Scroll::Cursor.new "#{feed_item.id}:#{feed_item.id}", field_name: '_id', field_type: BSON::ObjectId, direction: 1
+    end
+    its(:value) { should eq feed_item.id.to_s }
+    its(:tiebreak_id) { should eq feed_item.id }
+    its(:criteria) do
+      should eq('$or' => [
+        { '_id' => { '$gt' => BSON::ObjectId("#{feed_item.id}") } }
+      ])
+    end
+  end
   context 'a string field cursor' do
     let(:feed_item) { Feed::Item.create!(a_string: 'astring') }
     subject do
@@ -25,7 +38,7 @@ describe Mongoid::Scroll::Cursor do
     its(:criteria) do
       should eq('$or' => [
         { 'a_string' => { '$gt' => feed_item.a_string } },
-        { 'a_string' => feed_item.a_string, :_id => { '$gt' => feed_item.id } }
+        { 'a_string' => feed_item.a_string, '_id' => { '$gt' => feed_item.id } }
       ])
     end
   end
@@ -39,7 +52,7 @@ describe Mongoid::Scroll::Cursor do
     its(:criteria) do
       should eq('$or' => [
         { 'a_integer' => { '$gt' => feed_item.a_integer } },
-        { 'a_integer' => feed_item.a_integer, :_id => { '$gt' => feed_item.id } }
+        { 'a_integer' => feed_item.a_integer, '_id' => { '$gt' => feed_item.id } }
       ])
     end
   end
@@ -54,7 +67,7 @@ describe Mongoid::Scroll::Cursor do
     its(:criteria) do
       should eq('$or' => [
         { 'a_datetime' => { '$gt' => feed_item.a_datetime } },
-        { 'a_datetime' => feed_item.a_datetime, :_id => { '$gt' => feed_item.id } }
+        { 'a_datetime' => feed_item.a_datetime, '_id' => { '$gt' => feed_item.id } }
       ])
     end
   end
@@ -69,7 +82,7 @@ describe Mongoid::Scroll::Cursor do
     its(:criteria) do
       should eq('$or' => [
         { 'a_date' => { '$gt' => feed_item.a_date.to_datetime } },
-        { 'a_date' => feed_item.a_date.to_datetime, :_id => { '$gt' => feed_item.id } }
+        { 'a_date' => feed_item.a_date.to_datetime, '_id' => { '$gt' => feed_item.id } }
       ])
     end
   end
@@ -84,7 +97,7 @@ describe Mongoid::Scroll::Cursor do
     its(:criteria) do
       should eq('$or' => [
         { 'a_time' => { '$gt' => feed_item.a_time } },
-        { 'a_time' => feed_item.a_time, :_id => { '$gt' => feed_item.id } }
+        { 'a_time' => feed_item.a_time, '_id' => { '$gt' => feed_item.id } }
       ])
     end
   end
@@ -99,7 +112,7 @@ describe Mongoid::Scroll::Cursor do
     its(:criteria) do
       should eq('$or' => [
         { 'a_time' => { '$gt' => feed_item.a_time } },
-        { 'a_time' => feed_item.a_time, :_id => { '$gt' => feed_item.id } }
+        { 'a_time' => feed_item.a_time, '_id' => { '$gt' => feed_item.id } }
       ])
     end
   end

--- a/spec/mongoid/scroll_cursor_spec.rb
+++ b/spec/mongoid/scroll_cursor_spec.rb
@@ -17,15 +17,22 @@ describe Mongoid::Scroll::Cursor do
   end
   context 'an id field cursor' do
     let(:feed_item) { Feed::Item.create!(a_string: 'astring') }
+    field_type = Mongoid::Scroll.mongoid3? ? Moped::BSON::ObjectId : BSON::ObjectId
     subject do
-      Mongoid::Scroll::Cursor.new "#{feed_item.id}:#{feed_item.id}", field_name: '_id', field_type: BSON::ObjectId, direction: 1
+      Mongoid::Scroll::Cursor.new "#{feed_item.id}:#{feed_item.id}", field_name: '_id', field_type: field_type, direction: 1
     end
     its(:value) { should eq feed_item.id.to_s }
     its(:tiebreak_id) { should eq feed_item.id }
     its(:criteria) do
-      should eq('$or' => [
-        { '_id' => { '$gt' => BSON::ObjectId("#{feed_item.id}") } }
-      ])
+      if Mongoid::Scroll.mongoid3?
+        should eq('$or' => [
+          { '_id' => { '$gt' => Moped::BSON::ObjectId("#{feed_item.id}") } }
+        ])
+      else
+        should eq('$or' => [
+          { '_id' => { '$gt' => BSON::ObjectId("#{feed_item.id}") } }
+        ])
+      end
     end
   end
   context 'a string field cursor' do


### PR DESCRIPTION
Because of earlier changes to allow for logically complex criteria (https://github.com/dblock/mongoid-scroll/pull/5), the `cursor.criteria` was no longer passed into the mongoid `where` helper. This meant that the cursor criteria selectors were not merged, and string object IDs were not cast into `BSON::ObjectId`s (thus returning no results).

This PR adds two specs to catch the issue, and makes `cursor.criteria` return an actual `Origin::Selector` object instead of just a hash. The `__evolve_object_id__` method casts ids into `BSON::ObjectId`s if possible.

Example:
Without this change, calling `cursor.criteria` might return something like this:
```ruby
{"$or"=>[{"_id"=>{"$gt"=>"55ba8a16736172f243000002"}}, {"_id"=>"55ba8a16736172f243000002", :_id=>{"$gt"=>BSON::ObjectId('55ba8a16736172f243000002')}}]}
```

After the change, the passed-in ID is correctly cast and the fields are merged:
```ruby
{"$or"=>[{"_id"=>{"$gt"=>BSON::ObjectId('55ba8a67736172f274000002')}}]}
```
